### PR TITLE
Minor tweak to prevent subs CSS affecting settings

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -77,6 +77,12 @@ body.res-console-open {
 			overflow: hidden; // try to smooth the transition
 		}
 	}
+	
+	*, :before, :after {
+		-webkit-box-sizing: content-box;
+		-moz-box-sizing: content-box;
+		box-sizing: content-box;	
+	}
 
 	em {
 		font-style: italic;


### PR DESCRIPTION
I've noticed a few subs using `*, :after, :before { box-sizing: border-box; }`, which minorly affects a few things.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
